### PR TITLE
improve sweeper spawn logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,7 +72,7 @@ module.exports.loop = function () {
         var energyC = Game.spawns['Spawn1'].room.energyCapacityAvailable;
        
        
-       //If spawn is not spawning & has enough energy
+       //SPAWN LOGIC
        if(!Game.spawns['Spawn1'].spawning && (Game.rooms['W32N56'].energyAvailable > 299)){
            // Spawn missing creeps/roles
            if(miners.length < 3){
@@ -91,7 +91,7 @@ module.exports.loop = function () {
                console.log('Spawning new Builder!');
                Game.spawns['Spawn1'].createCustomCreep(energyA, 'builder');
            }
-           if(sweepers.length < 1){
+           if(sweepers.length < 1 && Game.spawns['Spawn1'].room.find(FIND_RUINS).filter(ruin => ruin.store.getUsedCapacity(RESOURCE_ENERGY) > 0)){
                console.log('Spawning new Sweeper!');
                Game.spawns['Spawn1'].createMuleCreep(energyA, 'sweeper');
            }


### PR DESCRIPTION
Improved sweeper spawn logic to check for ruins with energy available for collecting before spawning, effectively reducing idle sweeper creeps.

To improve, save number of sweepers to memory of room and run spawn check only every (x) ticks rather than every tick.