### PR TITLE
Hotfix sweeper issue9

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,7 +97,7 @@ module.exports.loop = function () {
                console.log('Spawning new Builder!');
                Game.spawns['Spawn1'].createCustomCreep(energyA, 'builder');
            }
-           if(sweepers.length < 1 && Game.spawns['Spawn1'].room.find(FIND_RUINS).filter(ruin => ruin.store.getUsedCapacity(RESOURCE_ENERGY) > 0)){
+           if(sweepers.length < 1 && Game.spawns['Spawn1'].room.find(FIND_RUINS).filter(ruin => ruin.store.getUsedCapacity(RESOURCE_ENERGY) > 0).length != 0){
                console.log('Spawning new Sweeper!');
                Game.spawns['Spawn1'].createMuleCreep(energyA, 'sweeper');
            }

--- a/role.sweeper.js
+++ b/role.sweeper.js
@@ -17,13 +17,17 @@ var roleSweeper = {
         }
         // If scavaging && inv not full
         if(creep.memory.scavaging && creep.store.getUsedCapacity([RESOURCE_ENERGY]) < creep.store.getCapacity([RESOURCE_ENERGY])){
-            if(creep.withdraw(closestRuin, RESOURCE_ENERGY) == ERR_NOT_IN_RANGE){
+            if(closestRuin && creep.withdraw(closestRuin, RESOURCE_ENERGY) == ERR_NOT_IN_RANGE){
                 creep.moveTo(closestRuin);
                 creep.say('Moving To closest Ruin!');
             }
             else{
                 if(closestRuin && closestRuin.store.getUsedCapacity([RESOURCE_ENERGY]) > 0){
                     creep.withdraw(closestRuin, RESOURCE_ENERGY);
+                }
+                if(creep.memory.scavaging == true && !closestRuin){
+                    console.log('No ruin with energy in room! Ending my existance~ Goodbye');
+                    creep.suicide();
                 }
             }
         }

--- a/role.sweeper.js
+++ b/role.sweeper.js
@@ -22,7 +22,7 @@ var roleSweeper = {
                 creep.say('Moving To closest Ruin!');
             }
             else{
-                if(closestRuin.store.getUsedCapacity([RESOURCE_ENERGY]) > 0){
+                if(closestRuin && closestRuin.store.getUsedCapacity([RESOURCE_ENERGY]) > 0){
                     creep.withdraw(closestRuin, RESOURCE_ENERGY);
                 }
             }


### PR DESCRIPTION
Tweak spawn code to include .length at end of sweeper spawn if statement - this prevents a spawn/suicide loop that occured.

Changed sweeper code to prevent null value in array closestRuin, now sweeper checks if closest ruin exists when using it.