### PR TITLE
Hotfix for mule logic

### DIFF
--- a/role.mule.js
+++ b/role.mule.js
@@ -35,7 +35,7 @@ var roleMule = {
             var closestPickup = creep.pos.findClosestByPath(requestingCreeps);
             var muleDuplicateTargets = _.filter(Game.creeps, (creep) => creep.memory.role == 'mule' && (Game.getObjectById(creep.memory.closestPickup)) == closestPickup);
             var memory_closestPickup = Game.getObjectById(creep.memory.closestPickup);
-            if(!creep.memory.closestPickup){
+            if(!creep.memory.closestPickup && requestingCreeps.length != 0){
                 if(muleDuplicateTargets.length > 1){
                     nextTarget = requestingCreeps;
                     nextTarget.splice(closestPickup, nextTarget[1]);
@@ -58,6 +58,9 @@ var roleMule = {
                 else{
                     if(closestPickup){
                     creep.memory.closestPickup = closestPickup.id; 
+                    }
+                    else{
+                        creep.moveTo(34,25); //NO REQUESTING PICKUP CREEPS 
                     }
                 }
             }

--- a/role.repair.js
+++ b/role.repair.js
@@ -15,7 +15,7 @@ var roleRepair = {
         var closestSource = creep.pos.findClosestByPath(serializedSources);
         var repair_target = creep.room.find(FIND_STRUCTURES, {
     	            filter: (structure) => {
-    	                return(structure.hits <= (structure.hitsMax *0.9) && structure.structureType === STRUCTURE_ROAD || structure.structureType === STRUCTURE_TOWER);
+    	                return(structure.hits <= (structure.hitsMax *0.9) && (structure.structureType === STRUCTURE_ROAD || structure.structureType === STRUCTURE_TOWER));
     	            }
     	        })
     	var closest_repair = creep.pos.findClosestByPath(repair_target);
@@ -38,10 +38,9 @@ var roleRepair = {
             // If repairing
     	    if(creep.memory.repairing) {
     	        // If repairTarget exists in memory
-                if(creep.memory.repairTarget) {
+                if(creep.memory.repairTarget && Game.getObjectById(creep.memory.repairTarget).hits != Game.getObjectById(creep.memory.repairTarget).hitsMax) {
                     if(creep.repair(memory_repairTarget) == ERR_NOT_IN_RANGE) {
                         creep.moveTo(memory_repairTarget, {visualizePathStyle: {stroke: '#ffffff'}});
-                        //console.log('Moving To ' + memory_repairTarget);
                     }
                     else{
                         creep.repair(memory_repairTarget);
@@ -55,11 +54,12 @@ var roleRepair = {
                         }
                     }
                 }
-                // If repairTarget not in memory, set it
+                // If repairTarget not in memory, or target in memory has max hits set it
                 else{
-                    console.log(closest_repair);
-                    creep.memory.repairTarget = closest_repair.id;
-                }
+                    if(repair_target.length > 0){
+                        creep.memory.repairTarget = closest_repair.id;
+                    }
+                }    
                 // If no buildings with hp < 80% stop repairing
                 if(repair_target.length == 0){
                     creep.memory.repairing = false;


### PR DESCRIPTION
Mules caused a break in code execution due to searching for an empty array